### PR TITLE
Support PHP 8.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
 
       - name: "Install PHP with extensions"
         uses: shivammathur/setup-php@v2
@@ -29,7 +29,7 @@ jobs:
         run: composer validate --strict
 
       - name: "Install locked dependencies with composer"
-        run: composer install --no-interaction --no-progress --no-suggest
+        run: composer install --no-interaction --no-progress
 
       - name: "Run localheinz/composer-normalize"
         run: composer normalize --dry-run
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
 
       - name: "Install PHP with extensions"
         uses: shivammathur/setup-php@v2
@@ -51,31 +51,25 @@ jobs:
           php-version: 7.4
 
       - name: "Install locked dependencies with composer"
-        run: composer install --no-interaction --no-progress --no-suggest
+        run: composer install --no-interaction --no-progress
 
       - name: "Run phpstan"
         run: vendor/bin/phpstan analyse --configuration=phpstan.neon
 
   tests:
-    name: "Tests"
+    name: Test for PHP ${{ matrix.php-version }} (${{ matrix.dependencies }})
 
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        php-version:
-          - 7.2
-          - 7.3
-          - 7.4
+        php-version: ['7.2', '7.3', '7.4', '8.0']
 
-        dependencies:
-          - lowest
-          - locked
-          - highest
+        dependencies: [prefer-lowest, prefer-stable]
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
 
       - name: "Install PHP with extensions"
         uses: shivammathur/setup-php@v2
@@ -84,17 +78,8 @@ jobs:
           extensions: mbstring
           php-version: ${{ matrix.php-version }}
 
-      - name: "Install lowest dependencies with composer"
-        if: matrix.dependencies == 'lowest'
-        run: composer update --prefer-lowest --no-interaction --no-progress --no-suggest
-
-      - name: "Install locked dependencies with composer"
-        if: matrix.dependencies == 'locked'
-        run: composer install --no-interaction --no-progress --no-suggest
-
-      - name: "Install highest dependencies with composer"
-        if: matrix.dependencies == 'highest'
-        run: composer update --no-interaction --no-progress --no-suggest
+      - name: "Install dependencies with composer"
+        run: composer update --${{ matrix.dependencies }} --no-interaction --no-progress
 
       - name: "Run unit tests with phpunit/phpunit"
         run: vendor/bin/phpunit
@@ -106,7 +91,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
 
       - name: "Install PHP with extensions"
         uses: shivammathur/setup-php@v2
@@ -116,7 +101,7 @@ jobs:
           php-version: 7.4
 
       - name: "Install locked dependencies with composer"
-        run: composer install --no-interaction --no-progress --no-suggest
+        run: composer install --no-interaction --no-progress
 
       - name: "Dump Xdebug filter with phpunit/phpunit"
         run: vendor/bin/phpunit --dump-xdebug-filter=.build/phpunit/xdebug-filter.php

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -63,9 +63,15 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0']
+        php-version:
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
 
-        dependencies: [prefer-lowest, prefer-stable]
+        dependencies:
+          - "prefer-lowest"
+          - "prefer-stable"
 
     steps:
       - name: "Checkout"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## 4.0.0
+
+### Added
+
+- Support PHP 8
+
+### Changed
+
+- Rename `Mixed` class to `MixedScalar` because `mixed` is a reserved name in PHP 8.
+  The GraphQL name of the scalar is still `Mixed` so the schema does not change.
+
 ## 3.1.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-stretch
+FROM php:8
 
 RUN apt-get update \
     && apt-get install -y \
@@ -6,13 +6,12 @@ RUN apt-get update \
         git \
         libzip-dev \
         zip \
-    && docker-php-ext-configure zip --with-libzip \
+    && docker-php-ext-configure zip \
     && docker-php-ext-install \
         zip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer \
-    && composer global require hirak/prestissimo --no-progress --no-suggest --no-interaction
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 ENV COMPOSER_ALLOW_SUPERUSER="1"
 
 WORKDIR /workdir

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A [RFC 5321](https://tools.ietf.org/html/rfc5321) compliant email.
 
 Arbitrary data encoded in JavaScript Object Notation. See https://www.json.org/.
 
-### [Mixed](src/MixedScalar.php)
+### [MixedScalar](src/MixedScalar.php)
 
 Loose type that allows any value. Be careful when passing in large `Int` or `Float` literals,
 as they may not be parsed correctly on the server side. Use `String` literals if you are

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A [RFC 5321](https://tools.ietf.org/html/rfc5321) compliant email.
 
 Arbitrary data encoded in JavaScript Object Notation. See https://www.json.org/.
 
-### [MixedScalar](src/MixedScalar.php)
+### [Mixed](src/MixedScalar.php)
 
 Loose type that allows any value. Be careful when passing in large `Int` or `Float` literals,
 as they may not be parsed correctly on the server side. Use `String` literals if you are

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A [RFC 5321](https://tools.ietf.org/html/rfc5321) compliant email.
 
 Arbitrary data encoded in JavaScript Object Notation. See https://www.json.org/.
 
-### [Mixed](src/Mixed.php)
+### [Mixed](src/MixedScalar.php)
 
 Loose type that allows any value. Be careful when passing in large `Int` or `Float` literals,
 as they may not be parsed correctly on the server side. Use `String` literals if you are

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php": "^7.2|^8.0",
+    "php": "^7.2 || ^8.0",
     "egulias/email-validator": "^2.1.17",
     "spatie/regex": "^1.4.1",
     "thecodingmachine/safe": "^1.0.3",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php": ">=7.2",
+    "php": "^7.2|^8.0",
     "egulias/email-validator": "^2.1.17",
     "spatie/regex": "^1.4.1",
     "thecodingmachine/safe": "^1.0.3",

--- a/src/MixedScalar.php
+++ b/src/MixedScalar.php
@@ -7,7 +7,7 @@ namespace MLL\GraphQLScalars;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Utils\AST;
 
-class Mixed extends ScalarType
+class MixedScalar extends ScalarType
 {
     /**
      * The description that is used for schema introspection.

--- a/src/MixedScalar.php
+++ b/src/MixedScalar.php
@@ -9,11 +9,8 @@ use GraphQL\Utils\AST;
 
 class MixedScalar extends ScalarType
 {
-    /**
-     * The description that is used for schema introspection.
-     *
-     * @var string
-     */
+    public $name = 'Mixed';
+
     public $description = <<<'DESCRIPTION'
 Loose type that allows any value. Be careful when passing in large `Int` or `Float` literals,
 as they may not be parsed correctly on the server side. Use `String` literals if you are

--- a/tests/MixedScalarTest.php
+++ b/tests/MixedScalarTest.php
@@ -9,10 +9,10 @@ use GraphQL\GraphQL;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Schema;
 use GraphQL\Type\SchemaConfig;
-use MLL\GraphQLScalars\Mixed;
+use MLL\GraphQLScalars\MixedScalar;
 use PHPUnit\Framework\TestCase;
 
-class MixedTest extends TestCase
+class MixedScalarTest extends TestCase
 {
     /**
      * @var Schema
@@ -23,7 +23,7 @@ class MixedTest extends TestCase
     {
         parent::setUp();
 
-        $mixed = new Mixed();
+        $mixed = new MixedScalar();
 
         $schemaConfig = new SchemaConfig();
         $schemaConfig->setQuery(
@@ -55,7 +55,7 @@ class MixedTest extends TestCase
     {
         $this->assertSame(
             $value,
-            (new Mixed())->serialize(
+            (new MixedScalar())->serialize(
                 $value
             )
         );
@@ -70,14 +70,14 @@ class MixedTest extends TestCase
     {
         $this->assertSame(
             $value,
-            (new Mixed())->serialize(
+            (new MixedScalar())->serialize(
                 $value
             )
         );
     }
 
     /**
-     * Provide an assortment of values that should pass the Mixed type.
+     * Provide an assortment of values that should pass the MixedScalar type.
      *
      * @return array[]
      */
@@ -180,7 +180,7 @@ class MixedTest extends TestCase
     protected function executeQueryWithJsonVariable(string $jsonLiteral): ExecutionResult
     {
         $query = '
-        query Foo($var: Mixed) {
+        query Foo($var: MixedScalar) {
             foo(bar: $var)
         }
         ';

--- a/tests/MixedScalarTest.php
+++ b/tests/MixedScalarTest.php
@@ -180,7 +180,7 @@ class MixedScalarTest extends TestCase
     protected function executeQueryWithJsonVariable(string $jsonLiteral): ExecutionResult
     {
         $query = '
-        query Foo($var: MixedScalar) {
+        query Foo($var: Mixed) {
             foo(bar: $var)
         }
         ';

--- a/tests/MixedScalarTest.php
+++ b/tests/MixedScalarTest.php
@@ -48,6 +48,8 @@ class MixedScalarTest extends TestCase
 
     /**
      * @dataProvider singleValues
+     *
+     * @param mixed $value Anything
      */
     public function testSerializePassesThroughAnything($value): void
     {

--- a/tests/MixedScalarTest.php
+++ b/tests/MixedScalarTest.php
@@ -48,8 +48,6 @@ class MixedScalarTest extends TestCase
 
     /**
      * @dataProvider singleValues
-     *
-     * @param mixed $value
      */
     public function testSerializePassesThroughAnything($value): void
     {
@@ -63,8 +61,6 @@ class MixedScalarTest extends TestCase
 
     /**
      * @dataProvider singleValues
-     *
-     * @param mixed $value
      */
     public function testParseValuePassesThroughAnything($value): void
     {
@@ -96,8 +92,6 @@ class MixedScalarTest extends TestCase
 
     /**
      * @dataProvider literalToPhpMap
-     *
-     * @param mixed $expected
      */
     public function testCastsValuesIntoAppropriatePhpValue(string $graphQLLiteral, string $jsonLiteral, $expected): void
     {

--- a/tests/MixedScalarTest.php
+++ b/tests/MixedScalarTest.php
@@ -61,6 +61,8 @@ class MixedScalarTest extends TestCase
 
     /**
      * @dataProvider singleValues
+     *
+     * @param mixed $value Anything
      */
     public function testParseValuePassesThroughAnything($value): void
     {
@@ -75,7 +77,7 @@ class MixedScalarTest extends TestCase
     /**
      * Provide an assortment of values that should pass the Mixed type.
      *
-     * @return array[]
+     * @return array<int, array<int, mixed>>
      */
     public function singleValues(): array
     {
@@ -92,6 +94,8 @@ class MixedScalarTest extends TestCase
 
     /**
      * @dataProvider literalToPhpMap
+     *
+     * @param mixed $expected Anything
      */
     public function testCastsValuesIntoAppropriatePhpValue(string $graphQLLiteral, string $jsonLiteral, $expected): void
     {
@@ -113,7 +117,7 @@ class MixedScalarTest extends TestCase
     /**
      * Provides a GraphQL literal, a JSON literal and the expected PHP value.
      *
-     * @return array[]
+     * @return array<int, array<int, mixed>>
      */
     public function literalToPhpMap(): array
     {

--- a/tests/MixedScalarTest.php
+++ b/tests/MixedScalarTest.php
@@ -77,7 +77,7 @@ class MixedScalarTest extends TestCase
     }
 
     /**
-     * Provide an assortment of values that should pass the MixedScalar type.
+     * Provide an assortment of values that should pass the Mixed type.
      *
      * @return array[]
      */
@@ -117,7 +117,7 @@ class MixedScalarTest extends TestCase
     }
 
     /**
-     * Provides a GraphQL literal, a Json literal and the expected PHP value.
+     * Provides a GraphQL literal, a JSON literal and the expected PHP value.
      *
      * @return array[]
      */


### PR DESCRIPTION
This pull request renames `Mixed` class to `MixedScalar` to support PHP 8.0.

GitHub Actions Workflow also has updated.

It will be a breaking change.