### PR TITLE
Allow installing master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "egulias/email-validator": "^2.1.17 || ^3",
     "spatie/regex": "^1.4",
     "thecodingmachine/safe": "^1.3",
-    "webonyx/graphql-php": "dev-phpstan-level-7 as dev-master"
+    "webonyx/graphql-php": "dev-master || dev-phpstan-level-7"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.16",


### PR DESCRIPTION
Currently, it is required to use only `dev-phpstan-level-7` branch