### PR TITLE
feat: add scalar specifiedBy URLs

### DIFF
--- a/src/BigInt.php
+++ b/src/BigInt.php
@@ -2,11 +2,22 @@
 
 namespace MLL\GraphQLScalars;
 
+use GraphQL\Type\Definition\ScalarType;
+
+/**
+ * @phpstan-import-type ScalarConfig from ScalarType
+ */
 class BigInt extends Regex
 {
     public ?string $description = <<<'DESCRIPTION'
 An arbitrarily long sequence of digits that represents a big integer.
 DESCRIPTION;
+
+    /** @phpstan-param ScalarConfig $config */
+    public function __construct(array $config = [])
+    {
+        parent::__construct($config + SpecifiesByReadme::readmeSpecification('bigint'));
+    }
 
     public static function regex(): string
     {

--- a/src/Date.php
+++ b/src/Date.php
@@ -2,10 +2,21 @@
 
 namespace MLL\GraphQLScalars;
 
+use GraphQL\Type\Definition\ScalarType;
+
+/**
+ * @phpstan-import-type ScalarConfig from ScalarType
+ */
 class Date extends DateScalar
 {
     public ?string $description /** @lang Markdown */
         = 'A date string with format `Y-m-d`, e.g. `2011-05-23`.';
+
+    /** @phpstan-param ScalarConfig $config */
+    public function __construct(array $config = [])
+    {
+        parent::__construct($config + SpecifiesByReadme::readmeSpecification('date'));
+    }
 
     protected static function outputFormat(): string
     {

--- a/src/DateTime.php
+++ b/src/DateTime.php
@@ -2,10 +2,21 @@
 
 namespace MLL\GraphQLScalars;
 
+use GraphQL\Type\Definition\ScalarType;
+
+/**
+ * @phpstan-import-type ScalarConfig from ScalarType
+ */
 class DateTime extends DateScalar
 {
     public ?string $description /** @lang Markdown */
         = 'A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`.';
+
+    /** @phpstan-param ScalarConfig $config */
+    public function __construct(array $config = [])
+    {
+        parent::__construct($config + SpecifiesByReadme::readmeSpecification('datetime'));
+    }
 
     protected static function outputFormat(): string
     {

--- a/src/DateTimeTz.php
+++ b/src/DateTimeTz.php
@@ -2,10 +2,21 @@
 
 namespace MLL\GraphQLScalars;
 
+use GraphQL\Type\Definition\ScalarType;
+
+/**
+ * @phpstan-import-type ScalarConfig from ScalarType
+ */
 class DateTimeTz extends DateScalar
 {
     public ?string $description /** @lang Markdown */
         = 'A datetime string with format `Y-m-d\TH:i:s.uP`, e.g. `2020-04-20T16:20:04.000000+04:00`.';
+
+    /** @phpstan-param ScalarConfig $config */
+    public function __construct(array $config = [])
+    {
+        parent::__construct($config + SpecifiesByReadme::readmeSpecification('datetimetz'));
+    }
 
     protected static function outputFormat(): string
     {

--- a/src/Email.php
+++ b/src/Email.php
@@ -4,11 +4,21 @@ namespace MLL\GraphQLScalars;
 
 use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\RFCValidation;
+use GraphQL\Type\Definition\ScalarType;
 
+/**
+ * @phpstan-import-type ScalarConfig from ScalarType
+ */
 class Email extends StringScalar
 {
     public ?string $description /** @lang Markdown */
         = 'A [RFC 5321](https://tools.ietf.org/html/rfc5321) compliant email.';
+
+    /** @phpstan-param ScalarConfig $config */
+    public function __construct(array $config = [])
+    {
+        parent::__construct($config + SpecifiesByReadme::readmeSpecification('email'));
+    }
 
     protected function isValid(string $stringValue): bool
     {

--- a/src/JSON.php
+++ b/src/JSON.php
@@ -7,10 +7,19 @@ use GraphQL\Language\Printer;
 use GraphQL\Type\Definition\ScalarType;
 use Safe\Exceptions\JsonException;
 
+/**
+ * @phpstan-import-type ScalarConfig from ScalarType
+ */
 class JSON extends ScalarType
 {
     public ?string $description /** @lang Markdown */
         = 'Arbitrary data encoded in JavaScript Object Notation. See https://www.json.org.';
+
+    /** @phpstan-param ScalarConfig $config */
+    public function __construct(array $config = [])
+    {
+        parent::__construct($config + SpecifiesByReadme::readmeSpecification('json'));
+    }
 
     public function serialize($value): string
     {

--- a/src/MixedScalar.php
+++ b/src/MixedScalar.php
@@ -5,6 +5,9 @@ namespace MLL\GraphQLScalars;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Utils\AST;
 
+/**
+ * @phpstan-import-type ScalarConfig from ScalarType
+ */
 class MixedScalar extends ScalarType
 {
     public string $name = 'Mixed';
@@ -14,6 +17,12 @@ class MixedScalar extends ScalarType
         as they may not be parsed correctly on the server side. Use `String` literals if you are
         dealing with really large numbers to be on the safe side.
         DESCRIPTION;
+
+    /** @phpstan-param ScalarConfig $config */
+    public function __construct(array $config = [])
+    {
+        parent::__construct($config + SpecifiesByReadme::readmeSpecification('mixed'));
+    }
 
     public function serialize($value)
     {

--- a/src/NullScalar.php
+++ b/src/NullScalar.php
@@ -7,6 +7,9 @@ use GraphQL\Error\InvariantViolation;
 use GraphQL\Language\AST\NullValueNode;
 use GraphQL\Type\Definition\ScalarType;
 
+/**
+ * @phpstan-import-type ScalarConfig from ScalarType
+ */
 class NullScalar extends ScalarType
 {
     public const ONLY_NULL_IS_ALLOWED = 'Only null is allowed.';
@@ -15,6 +18,12 @@ class NullScalar extends ScalarType
 
     public ?string $description /** @lang Markdown */
         = 'Always `null`. Strictly validates value is non-null, no coercion.';
+
+    /** @phpstan-param ScalarConfig $config */
+    public function __construct(array $config = [])
+    {
+        parent::__construct($config + SpecifiesByReadme::readmeSpecification('null'));
+    }
 
     public function serialize($value)
     {

--- a/src/SpecifiesByReadme.php
+++ b/src/SpecifiesByReadme.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace MLL\GraphQLScalars;
+
+use GraphQL\Type\Definition\ScalarType;
+
+/**
+ * @phpstan-import-type ScalarConfig from ScalarType
+ */
+final class SpecifiesByReadme
+{
+    /** @phpstan-return ScalarConfig */
+    public static function readmeSpecification(string $anchor): array
+    {
+        if (! property_exists(ScalarType::class, 'specifiedByURL')) {
+            return [];
+        }
+
+        return [
+            'specifiedByURL' => "https://github.com/mll-lab/graphql-php-scalars#{$anchor}",
+        ];
+    }
+}

--- a/tests/SchemaUsageTest.php
+++ b/tests/SchemaUsageTest.php
@@ -3,8 +3,11 @@
 namespace MLL\GraphQLScalars\Tests;
 
 use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Schema;
 use GraphQL\Type\SchemaConfig;
+use GraphQL\Utils\SchemaPrinter;
+use MLL\GraphQLScalars\Date;
 use MLL\GraphQLScalars\Email;
 use PHPUnit\Framework\TestCase;
 
@@ -30,5 +33,54 @@ final class SchemaUsageTest extends TestCase
         $schema = new Schema($schemaConfig);
 
         self::assertEmpty($schema->validate());
+    }
+
+    public function testScalarsSpecifyReadmeUrl(): void
+    {
+        self::requireSpecifiedByURLSupport();
+
+        $date = new Date();
+
+        self::assertSame('https://github.com/mll-lab/graphql-php-scalars#date', $date->specifiedByURL);
+    }
+
+    public function testExplicitSpecifiedByUrlTakesPrecedence(): void
+    {
+        self::requireSpecifiedByURLSupport();
+
+        $date = new Date([
+            'specifiedByURL' => 'https://example.com/custom-date-specification',
+        ]);
+
+        self::assertSame('https://example.com/custom-date-specification', $date->specifiedByURL);
+    }
+
+    public function testSchemaPrinterIncludesSpecifiedByDirective(): void
+    {
+        self::requireSpecifiedByURLSupport();
+
+        $date = new Date();
+
+        $schemaConfig = new SchemaConfig();
+        $schemaConfig->setQuery(new ObjectType([
+            'name' => 'Query',
+            'fields' => [
+                'date' => $date,
+            ],
+        ]));
+
+        $schema = new Schema($schemaConfig);
+
+        self::assertStringContainsString(
+            'scalar Date @specifiedBy(url: "https://github.com/mll-lab/graphql-php-scalars#date")',
+            SchemaPrinter::doPrint($schema)
+        );
+    }
+
+    private static function requireSpecifiedByURLSupport(): void
+    {
+        if (! property_exists(ScalarType::class, 'specifiedByURL')) {
+            self::markTestSkipped('webonyx/graphql-php does not support specifiedByURL yet.');
+        }
     }
 }


### PR DESCRIPTION
## Summary
Add README-anchor specifiedByURL defaults to built-in scalar classes so newer webonyx/graphql-php versions expose scalar specification URLs through SDL printing and introspection.

Consumers can still override specifiedByURL through scalar constructor config. On older webonyx/graphql-php versions without specifiedByURL support, the default config key is omitted.